### PR TITLE
TOPページでのルームリンクをリアルタイムに反映されるようにした

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -2,6 +2,7 @@
 
 class MessagesController < ApplicationController
   before_action :set_room, only: [:new, :create]
+  before_action :require_login
 
   def new
     @message = @room.messages.new

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -2,6 +2,7 @@
 
 class RoomsController < ApplicationController
   before_action :set_room, only: [:show, :edit, :update, :destroy]
+  before_action :require_login
 
   # GET /rooms or /rooms.json
   def index

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -24,7 +24,7 @@ class RoomsController < ApplicationController
 
   # POST /rooms or /rooms.json
   def create
-    # TODO: 数人でroomを作れるようにする　一旦ログインしているユーザーのみに紐付ける
+    # 選択されたフレンドと自分を紐づけてroomを作る
     @room = Room.new(room_params)
     @users = current_user.friends.where(id: room_user_params[:user_ids])
     @room.users.append([current_user, *@users])

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -8,4 +8,6 @@ class Room < ApplicationRecord
   broadcasts
 
   has_and_belongs_to_many :users
+
+  after_create_commit { broadcast_prepend_to "rooms" }
 end

--- a/app/views/home/_logged_in.html.erb
+++ b/app/views/home/_logged_in.html.erb
@@ -1,3 +1,5 @@
+<%= turbo_stream_from "rooms" %>
+
 <div class="row p-3">
   <aside class="col-md-4 card p-3" style="height: 200px;">
     <section class="user_info d-flex flex-row">
@@ -15,10 +17,12 @@
     <h1>Rooms</h1>
     <%= link_to "New room", new_room_path %>
     <div id="rooms">
-      <% @rooms.each do |room| %>
-          <%= link_to room, class: "roomLink" do%>
-            <%= render room %>
+      <%= turbo_frame_tag "rooms" do %>
+        <% @rooms.each do |room| %>
+          <%= link_to room, class: "roomLink" do %>
+            <%= render 'rooms/room', room: room %>
           <% end %>
+        <% end %>
       <% end %>
     </div>
   </div>

--- a/app/views/rooms/_form.html.erb
+++ b/app/views/rooms/_form.html.erb
@@ -1,24 +1,26 @@
-<%= form_with(model: room) do |form| %>
-  <% if room.errors.any? %>
-    <div style="color: red">
-      <h2><%= pluralize(room.errors.count, "error") %> prohibited this room from being saved:</h2>
+<%= turbo_frame_tag "new_room", target: "_top" do %>
+  <%= form_with(model: room) do |form| %>
+    <% if room.errors.any? %>
+      <div style="color: red">
+        <h2><%= pluralize(room.errors.count, "error") %> prohibited this room from being saved:</h2>
 
-      <ul>
-        <% room.errors.each do |error| %>
-          <li><%= error.full_message %></li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
-    <%= form.label :name %>
-    <%= form.text_field :name, class: 'form-control'%>
-
-
-  <%= form.collection_check_boxes(:user_ids, current_user.friends, :id, :username) do |user| %>
-    <%= user.label class: "d-block pb-1" do %>
-      <%= user.check_box %>
-      <%= user.text %>
+        <ul>
+          <% room.errors.each do |error| %>
+            <li><%= error.full_message %></li>
+          <% end %>
+        </ul>
+      </div>
     <% end %>
+      <%= form.label :name %>
+      <%= form.text_field :name, class: 'form-control'%>
+
+
+    <%= form.collection_check_boxes(:user_ids, current_user.friends, :id, :username) do |user| %>
+      <%= user.label class: "d-block pb-1" do %>
+        <%= user.check_box %>
+        <%= user.text %>
+      <% end %>
+    <% end %>
+    <%= form.submit "Create Room", class: "btn btn-primary"  %>
   <% end %>
-  <%= form.submit "Create Room", class: "btn btn-primary"  %>
 <% end %>

--- a/app/views/rooms/_room.html.erb
+++ b/app/views/rooms/_room.html.erb
@@ -1,14 +1,16 @@
-<div class="card m-2 p-2 d-flex flex-row" id="<%= dom_id room %>">
-  <div class="card-img-div pt-2">
-    <figure class="icon-circle"><img src="https://picsum.photos/id/238/540/540" alt="roomicon"></figure>  
+<%= turbo_frame_tag room do %>
+  <div class="card m-2 p-2 d-flex flex-row" id="<%= dom_id room %>">
+    <div class="card-img-div pt-2">
+      <figure class="icon-circle"><img src="https://picsum.photos/id/238/540/540" alt="roomicon"></figure>  
+    </div>
+    <div class="card-body">
+      <h4>
+        <strong>RoomName:</strong>
+        <%= room.name %>
+      </h4>
+      <h4 id="latest-message">
+        This is some text within a card body.
+      </h4>
+    </div>
   </div>
-  <div class="card-body">
-    <h4>
-      <strong>RoomName:</strong>
-      <%= room.name %>
-    </h4>
-    <h4 id="latest-message">
-      This is some text within a card body.
-    </h4>
-  </div>
-</div>
+<% end %>


### PR DESCRIPTION
# issue
[最新のトークルームが一番上にくる#48](https://github.com/k-karen/team_project/issues/48)
上記のissueを行おうとしていたが、TOPページのroomリンクにturboを導入する必要があると考えて行った。

# 概要
TOPページのroomリンクにturboを導入した

# 変えたこと・実装内容
- ログイン済みのトップページのルームリンクにturboを導入する
- roomページ、messagaページでのログイン要求処理
- TODOコメントが残っていたので削除

# 確認したこと
ログインしない状態でも、roomページ、messageページにアクセスできているのに気づいたので、修正しておいた。

# 参考
https://zenn.dev/shita1112/books/cat-hotwire-turbo/viewer/turbo-streams-websocket
