### PR TITLE
TOPページのroomへのリンクに、最新メッセージを表示する

### DIFF
--- a/app/views/home/_logged_in.html.erb
+++ b/app/views/home/_logged_in.html.erb
@@ -17,7 +17,6 @@
     <h1>Rooms</h1>
     <%= link_to "New room", new_room_path %>
     <%= turbo_frame_tag "rooms" do %>
-      <!-- TODO: リンクを動かせるようにする -->
       <% @rooms.each do |room| %>
         <%= render 'rooms/room', room: room %>
       <% end %>

--- a/app/views/rooms/_room.html.erb
+++ b/app/views/rooms/_room.html.erb
@@ -1,5 +1,5 @@
 <%= turbo_frame_tag room do %>
-  <%= link_to room, class: "roomLink" do %>
+  <%= link_to room, data: { turbo_frame: "_top" }, class: "roomLink" do %>
     <div class="card m-2 p-2 d-flex flex-row">
       <div class="card-img-div pt-2">
         <figure class="icon-circle"><img src="https://picsum.photos/id/238/540/540" alt="roomicon"></figure>  

--- a/app/views/rooms/_room.html.erb
+++ b/app/views/rooms/_room.html.erb
@@ -14,7 +14,9 @@
           <%= room.id %>
         </h4>
         <h4 id="latest-message">
-          This is some text within a card body.
+          <!-- 最新のメッセージを表示 TODO: turboを使ってメッセージ送信をトリガーにリアルタイムで並び替える -->
+          <% latest_message = room.messages.last %>
+          <%= latest_message&.content %>
         </h4>
       </div>
     </div>


### PR DESCRIPTION
# issue
[最新のトークルームが一番上にくる#48](https://github.com/k-karen/team_project/issues/48)

# 概要
- TOPページのroomリンクを修正
- roomごとの最新メッセージを表示した

# 変えたこと・実装内容
- data-turbo-frame`属性に"_top"を指定
- _room.html.erbで最新のメッセージが呼び出されるようにした。

# 確認したこと

# 参考
https://zenn.dev/shita1112/books/cat-hotwire-turbo/viewer/turbo-frames
