### PR TITLE
Feature/change profile page

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -31,6 +31,7 @@ class UsersController < ApplicationController
   end
 
   def edit
+    # TODO: biograpy等の編集と、パスワード等の変更を分ける
     @user = current_user
   end
 

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -8,4 +8,11 @@ module UsersHelper
     gravatar_url = "https://secure.gravatar.com/avatar/#{gravatar_id}?s=#{size}"
     image_tag(gravatar_url, alt: user.username, class: "gravatar")
   end
+
+  # 引数で与えられたユーザーの生年月日を表示する
+  def display_birthdate(user)
+    userbirthdate_year = user.age&.years
+    birthdate = userbirthdate_year&.ago
+    birthdate&.strftime("%Y/%m/%d")
+  end
 end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,17 +1,26 @@
 <div class="px-5">
   <div class="card p-3 d-flex flex-row" style="">
     <div class="card-img-div">
-       <%= gravatar_for current_user, size: 300 %>
+       <%= gravatar_for @user, size: 300 %>
     </div>
     <div class="card-body">
-      <h2 class="card-title"><!--<%= current_user.username %>--> マハーヴィーラ</h2>
-      <p class="card-text">1992/2/29</p>
-      <p class="card-text">主婦だったけど、趣味のお菓子作りでお店はじめました。</p>
+      <h2 class="card-title"><strong><%= @user.username %></strong></h2>
+      <p class="card-text"><%= display_birthdate @user %></p>
+      <p class="card-text"><%= @user.biography %></p>
+      <% if current_user == @user %>
         <%= link_to edit_user_profile_path do%>
           <button class="btn btn-primary">プロフィール変更</button>
         <% end %>
-        <%= link_to 'Logout', logout_path, data: { turbo_method: :delete } %>
-      </div>
+      <% end %>
     </div>
   </div>
+  <br>
+  <% if current_user != @user %>
+    <%= link_to friendships_path do%>
+      <button class="btn btn-secondary">
+        <i class="bi bi-arrow-left"></i>
+        友達一覧へ戻る
+      </button>
+    <% end %>
+  <% end %>
 </div>


### PR DESCRIPTION
# issue
[プロフィールページのUIの修正#58](https://github.com/k-karen/team_project/issues/58)

# 概要
-  プロフィールページのUIを修正

# 変えたこと・実装内容
- 生年月日を計算するhelperの追加
- username、biograpyの表示
- 現在ログインしているユーザーのページかで、表示するボタンを変えるようにした
    - ログインしているユーザーの場合: プロフィール変更ボタン
    - ログインしていないユーザーの場合: 友達一覧のページに戻るボタン

# 確認したこと

# 参考

# 備考
友達編集ページから、選択したユーザーのプロフィールページに遷移できるようにしないといけない
友達ではないユーザーのプロフィールページに飛べるのを直さないいけない

