### PR TITLE
friendのプロフィールへ飛べるリンクを追加

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -67,6 +67,7 @@ input {
 }
 
 /* homeページ room */
+
 .icon-circle{
   width: 80px;
   height: 80px;
@@ -117,6 +118,7 @@ input {
 }
 
 /* pre-login page */
+
 .center{
   background-color: #ededed;
   width: 100%;
@@ -176,4 +178,10 @@ animation :infinity-scroll-left 95s infinite linear 0.5s both;
 
 .d-demo__list li{
   padding-right: 10px;
+}
+
+/* Friends List page */
+
+.friendLink{
+  text-decoration: none;
 }

--- a/app/views/friendships/_friend.html.erb
+++ b/app/views/friendships/_friend.html.erb
@@ -1,13 +1,17 @@
   <%= turbo_frame_tag friend do %>
     <div class="col-md-4">
-      <div class="card mb-4">
-        <div class="card-body">
-          <h5 class="card-title d-flex justify-content-between">
-            <%= friend.username %>
-            <%= button_to '', friendship_path(friend.id), method: :delete, data: { turbo_confirm: '友達やめますか？' }, class: 'btn-close'%>
-          </h5>
-          <p class="card-text"><%= friend.email %></p>
-        </div>
+      <div class="mb-4 d-flex justify-content-evenly align-items-center">
+        <%= link_to user_path(friend.id), data: { turbo_frame: "_top" }, class: "friendLink" do %>
+          <div class="card">
+            <div class="card-body">
+              <h5 class="card-title d-flex justify-content-between">
+                <%= friend.username %>
+              </h5>
+              <p class="card-text"><%= friend.email %></p>
+            </div>
+          </div>
+        <% end %>
+        <%= button_to '', friendship_path(friend.id), method: :delete, data: { turbo_confirm: '友達やめますか？' }, class: 'btn-close m-0'%>
       </div>
     </div>
   <% end %>


### PR DESCRIPTION
# issue
[友達編集ページから、選択したユーザーのプロフィールページに遷移できるようにする#61](https://github.com/k-karen/team_project/issues/61)

# 概要
- /users/friendshipsにある友達のカードから、そのfriendのプロフィールに飛べるようにした

# 変えたこと・実装内容
- cardにlink_toの追加
- 友達削除ボタンを、カードの外側に配置

# 確認したこと

# 参考

