### PR TITLE
ソートを修正

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -6,7 +6,10 @@ class HomeController < ApplicationController
       current_user.rooms
         .left_joins(:messages)
         .group("rooms.id")
-        .order("max(messages.created_at) DESC, rooms.id desc")
+        .order(
+          Arel.sql("CASE WHEN COUNT(messages.id) = 0
+            THEN rooms.created_at ELSE MAX(messages.created_at) END DESC, rooms.id DESC"),
+        )
     else
       []
     end


### PR DESCRIPTION
# issue
ログイン後のTOPページのroomのソートを修正する
[#67](https://github.com/k-karen/team_project/issues/67)

# 概要
- home_controllerのindexアクションにおけるroomsの呼び出しを修正

# 変えたこと・実装内容
- roomにメッセージがない場合は、roomの作成時間で並び替える
- メッセージがある場合は、最新のメッセージの作成時間で並び替える

# 確認したこと
create room1
create room1におけるmessage
create room2
の順番で動作したとき、room1が一番上にきていた。

# 参考

