### PR TITLE
/users/:idと直打ちを制限した

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,6 +2,7 @@
 
 class UsersController < ApplicationController
   before_action :logged_in_user, only: [:edit, :update]
+  before_action :check_access, only: [:show]
   def new
     @user = User.new
   end
@@ -58,6 +59,12 @@ class UsersController < ApplicationController
     unless logged_in?
       flash[:alert] = "Please log in."
       redirect_to(login_url, status: :see_other)
+    end
+  end
+
+  def check_access
+    unless request.referer.present? && URI(request.referer).host == request.host
+      redirect_to(root_path, alert: "アクセスは許可されていません。")
     end
   end
 end


### PR DESCRIPTION
# issue
友達ではないユーザーのプロフィールページに飛べてしまうのを修正する
[#73](https://github.com/k-karen/team_project/issues/73)

# 概要
- /users/:idと直打ちすることで、友達ではないユーザーのプロフィールに飛べてしまっているので、直した

# 変えたこと・実装内容
- user_controllerのshowアクションに、beforeフィルタを設けて、直前のページ（リファラー）が存在し、かつ同じホストからのアクセスであるかを確認するようにした。

# 確認したこと
- request.refererの使い方

# 参考
https://gorails.com/forum/using-activestorage-how-do-i-restrict-a-file-that-can-only-be-accessed-through-links-and-not-outside-the-website
