### PR TITLE
/rooms/:idと直打ちを制限した

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,4 +9,10 @@ class ApplicationController < ActionController::Base
   def require_login
     redirect_to(login_path, alert: "ログインしてください") unless logged_in?
   end
+
+  def check_access
+    unless request.referer.present? && URI(request.referer).host == request.host
+      redirect_to(root_path, alert: "アクセスは許可されていません。")
+    end
+  end
 end

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -3,6 +3,7 @@
 class RoomsController < ApplicationController
   before_action :set_room, only: [:show, :edit, :update, :destroy]
   before_action :require_login
+  before_action :check_access, only: [:show]
 
   # GET /rooms or /rooms.json
   def index

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -61,10 +61,4 @@ class UsersController < ApplicationController
       redirect_to(login_url, status: :see_other)
     end
   end
-
-  def check_access
-    unless request.referer.present? && URI(request.referer).host == request.host
-      redirect_to(root_path, alert: "アクセスは許可されていません。")
-    end
-  end
 end


### PR DESCRIPTION
# issue
アクセスできないIDのroomページへのアクセスの制御
[#75](https://github.com/k-karen/team_project/issues/75)

# 概要
- /rooms/:idと直打ちすることで、アクセスできないはずのroomに飛べてしまっているので、直した

# 変えたこと・実装内容
- userにも同様の制限を設けていたので、そのメソッドをapplicationコントローラーに移動
- roomコントローラーのshowアクションに、before_actionメソットを追加

# 確認したこと

# 参考

