### PR TITLE
友達削除ボタンを、カードの内側に配置

### DIFF
--- a/app/views/friendships/_friend.html.erb
+++ b/app/views/friendships/_friend.html.erb
@@ -6,12 +6,12 @@
             <div class="card-body">
               <h5 class="card-title d-flex justify-content-between">
                 <%= friend.username %>
+                <%= button_to '', friendship_path(friend.id), method: :delete, data: { turbo_confirm: '友達やめますか？' }, class: 'btn-close m-0', onclick: "event.stopPropagation()" %>
               </h5>
               <p class="card-text"><%= friend.email %></p>
             </div>
           </div>
         <% end %>
-        <%= button_to '', friendship_path(friend.id), method: :delete, data: { turbo_confirm: '友達やめますか？' }, class: 'btn-close m-0'%>
       </div>
     </div>
   <% end %>


### PR DESCRIPTION
以下のgifの様に、aタグの中にあるbuttonのonClickに、イベントが親に伝播しないようにしました。
![g2-Brave2024-01-2123-36-251-ezgif com-video-to-gif-converter](https://github.com/k-karen/team_project/assets/64852663/f5982555-594b-4d92-b4df-3f56fb93c6cb)

# 変えたこと・実装内容
- 友達削除ボタンに、onclick属性でstopPropagation() メソッドを設定した。