### PR TITLE
自分のプロフィールページにアクセスできなくなっていたので修正した

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,7 +7,11 @@ class UsersController < ApplicationController
   end
 
   def show
-    @user = current_user.friends.find(params[:id])
+    @user = if params[:id] == current_user.id.to_s
+      current_user
+    else
+      current_user.friends.find(params[:id])
+    end
   end
 
   def create


### PR DESCRIPTION
404用の処理を追加 #78

上記のPRでは、プロフィールページにアクセスする際、current_userに紐づいている友達をidで探索している。
この場合だと、自分のプロフィールページにアクセスできなくなっていたので、修正した。