### PR TITLE
ログイン後のトップページのリンクのUIを修正

### DIFF
--- a/app/views/home/_logged_in.html.erb
+++ b/app/views/home/_logged_in.html.erb
@@ -1,21 +1,28 @@
 <%= turbo_stream_from "rooms" %>
 
 <div class="row p-3">
-  <aside class="col-md-4 card p-3" style="height: 200px;">
-    <section class="user_info d-flex flex-row">
+  <aside class="col-md-4" style="height: 200px;">
+    <section class="user_info card p-3 d-flex flex-row">
       <div class="card-img-div">
         <%= gravatar_for current_user, size: 100 %>
       </div>
       <div class="card-body">
         <h2><%= current_user.username %></h2>
         <%= link_to "view my profile", current_user %>
-        <%= link_to "友達編集ページ", friendships_path %>
+        <br>
+        <%= link_to friendships_path do %>
+          <%= pluralize(current_user.friends.count, "friend") %>
+        <% end %>
       </div>
     </section>
   </aside>
   <div class="col-md-8">
-    <h1>Rooms</h1>
-    <%= link_to "New room", new_room_path %>
+    <h1 class="d-flex justify-content-between m-0">
+      Rooms
+      <%= link_to new_room_path do %>
+        <i class="bi bi-plus"></i>
+      <% end %>
+    </h1>
     <%= turbo_frame_tag "rooms" do %>
       <% @rooms.each do |room| %>
         <%= render 'rooms/room', room: room %>


### PR DESCRIPTION
# issue
ログイン後のトップページのリンクのUIを修正
[#87](https://github.com/k-karen/team_project/issues/87)

# 概要
- ログイン後のトップページのリンクの見た目を整えた

# 変えたこと・実装内容
新規ルーム作成
<img width="380" alt="SnapCrab_NoName_2024-1-22_2-11-15_No-00" src="https://github.com/k-karen/team_project/assets/64852663/15a53136-0e00-4657-abc8-86f8f7c21b4f">

friend
単数
<img width="111" alt="SnapCrab_NoName_2024-1-22_2-10-53_No-00" src="https://github.com/k-karen/team_project/assets/64852663/7cecdcfe-8db9-46fb-bd26-22284fbcf6c8">

複数
<img width="118" alt="SnapCrab_NoName_2024-1-22_2-12-14_No-00" src="https://github.com/k-karen/team_project/assets/64852663/4b5eb823-690f-4f20-9bfa-5c3052d38748">


# 確認したこと

# 参考

