### PR TITLE
Feature/flash comment

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,7 +9,7 @@ class ApplicationController < ActionController::Base
   end
 
   def require_login
-    redirect_to(login_path, alert: "ログインしてください") unless logged_in?
+    redirect_to(login_path, alert: "Please login!") unless logged_in?
   end
 
   def record_not_found(_execption)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,21 +2,21 @@
 
 class SessionsController < ApplicationController
   def new
-    redirect_to(root_path, notice: "ログイン済みです") if logged_in?
+    redirect_to(root_path, notice: "Already logged in") if logged_in?
   end
 
   def create
     if login(params[:email], params[:password])
       redirect_back_or_to(root_path, notice: "Login successful")
     else
-      flash[:alert] = "ログインに失敗しました"
+      flash[:alert] = "login failed"
       redirect_to(action: :new)
     end
   end
 
   def destroy
     logout
-    flash[:notice] = "ログアウトしました"
+    flash[:notice] = "logged out"
     redirect_to(root_path)
   end
 end

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -1,5 +1,3 @@
-<p style="color: green"><%= notice %></p>
-
 <%= turbo_stream_from @room %>
 
 <!-- ルームアクション -->


### PR DESCRIPTION
# issue
flashのコメントが、日本語と英語が混じっているをどちらかに統一する
[#91](https://github.com/k-karen/team_project/issues/91)

# 概要
- flashのコメントを英語に統一した
- room作成時に、flashが二重にでていたので、囲みがなく文字だけが表示されていた方を削除した。

# 変えたこと・実装内容
変更前
<img width="679" alt="SnapCrab_NoName_2024-1-22_17-5-55_No-00" src="https://github.com/k-karen/team_project/assets/64852663/198b7f72-4948-4456-87ac-590773179404">
⇓
変更後
<img width="550" alt="SnapCrab_NoName_2024-1-22_17-7-19_No-00" src="https://github.com/k-karen/team_project/assets/64852663/8529237c-e952-4577-8bd4-eae2206b152b">


# 確認したこと

# 参考

