### PR TITLE
最新時間を表示(設定した保持時間が経過後、表示されなくなる)

### DIFF
--- a/app/helpers/rooms_helper.rb
+++ b/app/helpers/rooms_helper.rb
@@ -4,4 +4,15 @@ module RoomsHelper
   def my_room_list_stream
     "user_#{current_user.id}_rooms"
   end
+
+  def format_date(created_time)
+    current_date = Time.now.in_time_zone.to_date
+    if created_time.to_date == current_date
+      # 今日の場合、hh:mm形式で出力
+      created_time.strftime("%H:%M")
+    else
+      # それ以外の場合、mm/dd形式で出力
+      created_time.strftime("%m/%d")
+    end
+  end
 end

--- a/app/views/rooms/_room.html.erb
+++ b/app/views/rooms/_room.html.erb
@@ -9,14 +9,20 @@
           <strong>RoomName:</strong>
           <%= room.name %>
         </h4>
-        <h4>
-          <strong>id:</strong>
-          <%= room.id %>
-        </h4>
-        <h4 id="latest-message">
+        <div class="d-flex justify-content-between" id="latest-message"> 
+          
           <% latest_message = room.messages.last %>
-          <%= latest_message&.content %>
-        </h4>
+          <% retention_time = Time.now.in_time_zone - room.retention_minutes.minutes %>
+
+          <% if latest_message && latest_message.created_at > retention_time %>
+            <h4>
+              <%= latest_message.content %>
+            </h4>
+            <p>
+              <%= format_date(latest_message&.created_at) %>
+            </p>
+          <% end %>
+        </div>
       </div>
     </div>
   <% end %>


### PR DESCRIPTION
# issue
ログイン後のTOPページのroomリンクに、最新のメッセージ時間を表示する
[#111](https://github.com/k-karen/team_project/issues/111)

# 概要
- ログイン後のTOPページのroomリンクに、最新のメッセージ時間を表示する

# 変えたこと・実装内容
roomの保持時間を経過したmessageは、最新のメッセージであってもTOPページに表示されないようになっている

<img width="590" alt="SnapCrab_NoName_2024-1-24_22-1-18_No-00" src="https://github.com/k-karen/team_project/assets/64852663/12ffa9b3-41ce-4a4e-a5b4-e3ad317f146b">





