### PR TITLE
userモデルのageカラムを生年月日に変える

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -71,7 +71,7 @@ class UsersController < ApplicationController
   end
 
   def user_profile_params
-    params.require(:user).permit(:biography, :age)
+    params.require(:user).permit(:biography, :birthday)
   end
 
   # beforeフィルタ

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -8,11 +8,4 @@ module UsersHelper
     gravatar_url = "https://secure.gravatar.com/avatar/#{gravatar_id}?s=#{size}"
     image_tag(gravatar_url, alt: user.username, class: "gravatar")
   end
-
-  # 引数で与えられたユーザーの生年月日を表示する
-  def display_birthdate(user)
-    userbirthdate_year = user.age&.years
-    birthdate = userbirthdate_year&.ago
-    birthdate&.strftime("%Y/%m/%d")
-  end
 end

--- a/app/views/users/edit_profile.html.erb
+++ b/app/views/users/edit_profile.html.erb
@@ -12,8 +12,8 @@
 
     <%= form_with(model: @user, url: update_user_profile_path, method: :patch) do |f| %>
 
-      <%= f.label :age %>
-      <%= f.number_field :age, class: 'form-control' %>
+      <%= f.label :birthday %>
+      <%= f.date_field :birthday, class: 'form-control' %>
   
       <%= f.label :biography %>
       <%= f.text_area :biography, class: 'form-control', rows: "5" %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -13,7 +13,7 @@
         <% end %>
       </div>
       
-      <p class="card-text"><%= display_birthdate @user %></p>
+      <p class="card-text"><%= @user.birthday %></p>
       <p class="card-text"><%= @user.biography %></p>
       <% if current_user == @user %>
         <%= link_to edit_user_profile_path do%>

--- a/db/migrate/20240125002645_add_birthday_to_users.rb
+++ b/db/migrate/20240125002645_add_birthday_to_users.rb
@@ -1,0 +1,5 @@
+class AddBirthdayToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :birthday, :date
+  end
+end

--- a/db/migrate/20240125002819_remove_age_from_users.rb
+++ b/db/migrate/20240125002819_remove_age_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveAgeFromUsers < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :users, :age, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_11_202255) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_25_002819) do
   create_table "friendships", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "friend_id", null: false
@@ -59,8 +59,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_11_202255) do
     t.string "activation_state"
     t.string "activation_token"
     t.datetime "activation_token_expires_at"
-    t.integer "age"
     t.string "biography"
+    t.date "birthday"
     t.index ["activation_token"], name: "index_users_on_activation_token"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["username"], name: "index_users_on_username", unique: true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -13,7 +13,7 @@ users = []
     email: "sample_#{i}@example.com",
     password: "aiit-password",
     username: Faker::Internet.unique.username,
-    age: rand(18..100),
+    birthday: Faker::Date.birthday(min_age: 18, max_age: 100),
     biography: Faker::Lorem.sentence,
   )
   user.activate!


### PR DESCRIPTION
# issue
userモデルのageカラムを生年月日に変える
[#113](https://github.com/k-karen/team_project/issues/113)

# 概要
- usersテーブルのカラムage:integerをbirthday:dateに変更 
- ageのままだと、誕生日が全員todayの日付になっていたため修正

# 変えたこと・実装内容
- rails g migration AddBirthdayToUsers birthday:date の実行
- rails g migration RemoveAgeFromUsers age:integer の実行
- データベース変更に伴い、seeds.rbの変更
- プロフィールページ、プロフィール編集ページのage部分を変更
- users_controllerも変更

<img width="414" alt="SnapCrab_NoName_2024-1-25_16-24-42_No-00" src="https://github.com/k-karen/team_project/assets/64852663/ecb1ce07-870c-4561-8f65-4bf86199d723">

